### PR TITLE
Restored LPPE transitions back to the login webflow.

### DIFF
--- a/cas-mfa-web/src/main/webapp/WEB-INF/login-webflow.xml
+++ b/cas-mfa-web/src/main/webapp/WEB-INF/login-webflow.xml
@@ -58,6 +58,49 @@
         <transition to="generateLoginTicket"/>
     </action-state>
 	
+    <!--
+        LPPE transitions begin here: You will also need to
+        move over the 'lppe-configuration.xml' file from the
+        'unused-spring-configuration' folder to the 'spring-configuration' folder
+        so CAS can pick up the definition for the bean 'passwordPolicyAction'.
+    -->
+    <action-state id="passwordPolicyCheck">
+        <evaluate expression="passwordPolicyAction" />
+        <transition on="showWarning" to="passwordServiceCheck" />
+        <transition on="success" to="sendTicketGrantingTicket" />
+        <transition on="error" to="viewLoginForm" />
+    </action-state>
+
+    <action-state id="passwordServiceCheck">
+        <evaluate expression="sendTicketGrantingTicketAction" />
+        <transition to="passwordPostCheck" />
+    </action-state>
+
+    <decision-state id="passwordPostCheck">
+        <if test="flowScope.service != null" then="warnPassRedirect" else="pwdWarningPostView" />
+    </decision-state>
+
+    <action-state id="warnPassRedirect">
+        <evaluate expression="generateServiceTicketAction" />
+        <transition on="success" to="pwdWarningPostView" />
+        <transition on="error" to="generateLoginTicket" />
+        <transition on="gateway" to="gatewayServicesManagementCheck" />
+    </action-state>
+
+    <end-state id="pwdWarningAbstractView">
+        <on-entry>
+            <set name="flowScope.passwordPolicyUrl" value="passwordPolicyAction.getPasswordPolicyUrl()" />
+        </on-entry>
+    </end-state>
+    <end-state id="pwdWarningPostView" view="casWarnPassView" parent="#pwdWarningAbstractView" />
+    <end-state id="casExpiredPassView" view="casExpiredPassView" parent="#pwdWarningAbstractView" />
+    <end-state id="casMustChangePassView" view="casMustChangePassView" parent="#pwdWarningAbstractView" />
+    <end-state id="casAccountDisabledView" view="casAccountDisabledView" />
+    <end-state id="casAccountLockedView" view="casAccountLockedView" />
+    <end-state id="casBadHoursView" view="casBadHoursView" />
+    <end-state id="casBadWorkstationView" view="casBadWorkstationView" />
+    <!-- LPPE transitions end here... -->
+  
 	<!-- 
 		The "warn" action makes the determination of whether to redirect directly to the requested
 		service or display the "confirmation" page to go back to the server.
@@ -92,6 +135,12 @@
 		<transition on="error" to="generateLoginTicket" />
         <transition on="mfa_strong_two_factor" to="mfa_strong_two_factor" />
         <transition on="mfa_sample_two_factor" to="mfa_sample_two_factor" />
+        <transition on="accountDisabled" to="casAccountDisabledView" />
+        <transition on="mustChangePassword" to="casMustChangePassView" />
+        <transition on="accountLocked" to="casAccountLockedView" />
+        <transition on="badHours" to="casBadHoursView" />
+        <transition on="badWorkstation" to="casBadWorkstationView" />
+        <transition on="passwordExpired" to="casExpiredPassView" />
 	</action-state>
 	
 	<action-state id="sendTicketGrantingTicket">
@@ -180,7 +229,7 @@
              instead of showing an intermediate unauthorized view with a link to login page -->
         <transition to="viewLoginForm" on-exception="org.jasig.cas.services.UnauthorizedSsoServiceException"/>
         <transition to="viewServiceErrorView" on-exception="org.springframework.webflow.execution.repository.NoSuchFlowExecutionException" />
-	<transition to="viewServiceErrorView" on-exception="org.jasig.cas.services.UnauthorizedServiceException" />
+	    <transition to="viewServiceErrorView" on-exception="org.jasig.cas.services.UnauthorizedServiceException" />
         <transition to="ticketGrantingTicketExistsCheck" on-exception="net.unicon.cas.mfa.web.flow.NoAuthenticationContextAvailable" />
         <transition to="viewMfaUnrecognizedAuthnMethodErrorView" on-exception="net.unicon.cas.mfa.web.support.UnrecognizedAuthenticationMethodException" />
         


### PR DESCRIPTION
Relates to https://github.com/Unicon/cas-mfa/issues/10

LPPE functionality isn't actually tested and verified with MFA. This is to only reduce the number of diffs in the login flow.
