### PR TITLE
Respect method parameter

### DIFF
--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/DefaultRegisteredServiceMfaRoleProcessorImpl.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/DefaultRegisteredServiceMfaRoleProcessorImpl.java
@@ -6,6 +6,7 @@ import net.unicon.cas.mfa.web.support.MultiFactorWebApplicationServiceFactory;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.principal.WebApplicationService;
+import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.slf4j.Logger;
@@ -158,6 +159,9 @@ public class DefaultRegisteredServiceMfaRoleProcessorImpl implements RegisteredS
     private MultiFactorAuthenticationRequestContext getMfaRequestContext(final ServiceMfaData serviceMfaData,
                                                                          final String attributeValue,
                                                                          final WebApplicationService targetService) {
+        final RegisteredService registeredService = this.servicesManager.findServiceBy(targetService);
+        final RegisteredServiceWithAttributes service = RegisteredServiceWithAttributes.class.cast(registeredService);
+        final String method = String.class.cast(service.getExtraAttributes().get("method"));
 
         if (match(serviceMfaData.getAttributePattern(), attributeValue)) {
             if (!this.authenticationMethodConfiguration.containsAuthenticationMethod(serviceMfaData.getAuthenticationMethod())) {
@@ -170,7 +174,7 @@ public class DefaultRegisteredServiceMfaRoleProcessorImpl implements RegisteredS
                     serviceMfaData.getAuthenticationMethod()).getRank();
             final MultiFactorAuthenticationSupportingWebApplicationService svc =
                     this.mfaServiceFactory.create(targetService.getId(), targetService.getId(),
-                            targetService.getArtifactId(), serviceMfaData.getAuthenticationMethod(),
+                            targetService.getArtifactId(), "POST".equals(method) ? ResponseType.POST : ResponseType.REDIRECT, serviceMfaData.getAuthenticationMethod(),
                             MultiFactorAuthenticationSupportingWebApplicationService.AuthenticationMethodSource.PRINCIPAL_ATTRIBUTE);
 
             return new MultiFactorAuthenticationRequestContext(svc, mfaMethodRank);

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/principal/PrincipalAttributeMultiFactorAuthenticationRequestResolver.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/principal/PrincipalAttributeMultiFactorAuthenticationRequestResolver.java
@@ -162,7 +162,7 @@ public class PrincipalAttributeMultiFactorAuthenticationRequestResolver implemen
             final int mfaMethodRank = this.authenticationMethodConfiguration.getAuthenticationMethod(mfaMethod).getRank();
             final MultiFactorAuthenticationSupportingWebApplicationService svc =
                     this.mfaServiceFactory.create(targetService.getId(), targetService.getId(),
-                            targetService.getArtifactId(), mfaMethod, AuthenticationMethodSource.PRINCIPAL_ATTRIBUTE);
+                            targetService.getArtifactId(), null, mfaMethod, AuthenticationMethodSource.PRINCIPAL_ATTRIBUTE);
 
             return new MultiFactorAuthenticationRequestContext(svc, mfaMethodRank);
         }

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/AbstractMultiFactorAuthenticationArgumentExtractor.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/AbstractMultiFactorAuthenticationArgumentExtractor.java
@@ -5,6 +5,7 @@ import net.unicon.cas.mfa.authentication.StubAuthenticationMethodTranslator;
 import org.apache.commons.lang.StringUtils;
 import org.jasig.cas.authentication.principal.WebApplicationService;
 import org.jasig.cas.web.support.ArgumentExtractor;
+import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,7 @@ import java.util.List;
 
 import static net.unicon.cas.mfa.web.support.MultiFactorAuthenticationSupportingWebApplicationService.AuthenticationMethodSource;
 import static net.unicon.cas.mfa.web.support.MultiFactorAuthenticationSupportingWebApplicationService.CONST_PARAM_AUTHN_METHOD;
+import static net.unicon.cas.mfa.web.support.MultiFactorAuthenticationSupportingWebApplicationService.CONST_PARAM_METHOD;
 
 /**
  * Abstract extractor containing common functionality pertaining to authentication methods verification and target service extraction
@@ -75,9 +77,12 @@ public abstract class AbstractMultiFactorAuthenticationArgumentExtractor impleme
         authenticationMethod = this.authenticationMethodTranslator.translate(targetService, authenticationMethod);
         this.authenticationMethodVerifier.verifyAuthenticationMethod(authenticationMethod, targetService, request);
 
+        // Grab the HTTP method for the response off of the request.
+        final String method = request.getParameter(CONST_PARAM_METHOD);
+
         final MultiFactorAuthenticationSupportingWebApplicationService mfaService =
                 this.mfaWebApplicationServiceFactory.create(targetService.getId(), targetService.getId(), targetService.getArtifactId(),
-                        authenticationMethod, getAuthenticationMethodSource());
+                        "POST".equals(method) ? ResponseType.POST : ResponseType.REDIRECT, authenticationMethod, getAuthenticationMethodSource());
 
         logger.debug("Created multifactor authentication service instance for [{}] with [{}] as [{}] "
                 + "and authentication method definition source [{}].",

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorAuthenticationSupportingWebApplicationService.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorAuthenticationSupportingWebApplicationService.java
@@ -5,6 +5,7 @@ import org.jasig.cas.authentication.principal.AbstractWebApplicationService;
 import org.jasig.cas.authentication.principal.Response;
 import org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl;
 import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,13 +46,14 @@ public final class DefaultMultiFactorAuthenticationSupportingWebApplicationServi
      * @param id the service id, potentially with a jsessionid; still needing excised
      * @param originalUrl the service url
      * @param artifactId the artifact id
+     * @param responseType the HTTP method for the response
      * @param httpClient http client to process requests
      * @param authnMethod the authentication method required for this service
      */
     public DefaultMultiFactorAuthenticationSupportingWebApplicationService(final String id, final String originalUrl,
-            final String artifactId, final HttpClient httpClient, @NotNull final String authnMethod) {
+            final String artifactId, final ResponseType responseType, final HttpClient httpClient, @NotNull final String authnMethod) {
         super(cleanupUrl(id), originalUrl, artifactId, httpClient);
-        this.wrapperService = new SimpleWebApplicationServiceImpl(id, httpClient);
+        this.wrapperService = new SimpleWebApplicationServiceImpl(id, originalUrl, artifactId, responseType, httpClient);
         this.authenticationMethod = authnMethod;
     }
 
@@ -100,7 +102,7 @@ public final class DefaultMultiFactorAuthenticationSupportingWebApplicationServi
             final String artifactId, final HttpClient httpClient,
             @NotNull final String authnMethod,
             @NotNull final AuthenticationMethodSource authenticationMethodSource) {
-        this(id, originalUrl, artifactId, httpClient, authnMethod);
+        this(id, originalUrl, artifactId, null, httpClient, authnMethod);
         this.authenticationMethodSource = authenticationMethodSource;
     }
 

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorWebApplicationServiceFactory.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorWebApplicationServiceFactory.java
@@ -51,7 +51,7 @@ public final class DefaultMultiFactorWebApplicationServiceFactory implements Mul
         Assert.notNull(authenticationMethodSource, "authenticationMethodSource cannot be null.");
 
         return new DefaultMultiFactorAuthenticationSupportingWebApplicationService(
-                id, originalUrl, artifactId,
+                id, originalUrl, artifactId, responseType,
                 getHttpClientIfSingleSignOutEnabled(),
                 authenticationMethod, authenticationMethodSource);
     }

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorWebApplicationServiceFactory.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorWebApplicationServiceFactory.java
@@ -1,6 +1,7 @@
 package net.unicon.cas.mfa.web.support;
 
 import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -42,6 +43,7 @@ public final class DefaultMultiFactorWebApplicationServiceFactory implements Mul
     public MultiFactorAuthenticationSupportingWebApplicationService create(final String id,
                                                                            final String originalUrl,
                                                                            final String artifactId,
+                                                                           final ResponseType responseType,
                                                                            final String authenticationMethod,
                                                                            final AuthenticationMethodSource authenticationMethodSource) {
 

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorAuthenticationSupportingWebApplicationService.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorAuthenticationSupportingWebApplicationService.java
@@ -18,6 +18,12 @@ public interface MultiFactorAuthenticationSupportingWebApplicationService extend
     String CONST_PARAM_METHOD = "method";
 
     /**
+     * Parameter name that defines the service ticket to send back
+     * to the service.
+     */
+    String CONST_PARAM_TICKET = "ticket";
+
+    /**
      * Define the authentication method accepted and supported by this MFA service.
      * @return the supported method
      */

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorAuthenticationSupportingWebApplicationService.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorAuthenticationSupportingWebApplicationService.java
@@ -12,6 +12,12 @@ public interface MultiFactorAuthenticationSupportingWebApplicationService extend
     String CONST_PARAM_AUTHN_METHOD = "authn_method";
 
     /**
+     * Parameter name that defines the HTTP method used to send the
+     * authentication response back to a service.
+     */
+    String CONST_PARAM_METHOD = "method";
+
+    /**
      * Define the authentication method accepted and supported by this MFA service.
      * @return the supported method
      */

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorWebApplicationServiceFactory.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/MultiFactorWebApplicationServiceFactory.java
@@ -1,6 +1,7 @@
 package net.unicon.cas.mfa.web.support;
 
 import static net.unicon.cas.mfa.web.support.MultiFactorAuthenticationSupportingWebApplicationService.AuthenticationMethodSource;
+import org.jasig.cas.authentication.principal.Response.ResponseType;
 
 /**
  * Factory abstraction for creating instances of
@@ -26,6 +27,7 @@ public interface MultiFactorWebApplicationServiceFactory {
     MultiFactorAuthenticationSupportingWebApplicationService create(String id,
                                                                     String originalUrl,
                                                                     String artifactId,
+                                                                    ResponseType responseType,
                                                                     String authnMethod,
                                                                     AuthenticationMethodSource authenticationMethodSource);
 


### PR DESCRIPTION
Respect the method parameter that one can send to CAS as described [here](https://wiki.jasig.org/display/CASUM/Applications+that+Require+POST+Responses).

This PR won't quite work exactly the way it is since the `SimpleWebApplicationServiceImpl` constructor I want to use is private. There's probably a better way to do this than to use that constructor and make it public but this is a first attempt at what I'm trying to achieve. 

How do we make this work properly? 