### PR TITLE
if renew parameter is detected, proceed with normal flow

### DIFF
--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/ValidateInitialMultiFactorAuthenticationRequestAction.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/ValidateInitialMultiFactorAuthenticationRequestAction.java
@@ -147,6 +147,10 @@ public final class ValidateInitialMultiFactorAuthenticationRequestAction extends
             return new Event(this, EVENT_ID_REQUIRE_TGT);
         }
 
+        if (context.getRequestParameters().get("renew") != null) {
+            return new Event(this, EVENT_ID_REQUIRE_TGT);
+        }
+
         logger.trace("Authentication method [{}] is STRONGER than any previously fulfilled methods [{}]; "
                 + "branching to prompt for required authentication method.",
                 requestedAuthenticationMethod, previouslyAchievedAuthenticationMethods);


### PR DESCRIPTION
Just invoke the requireTgt transition if a renew parameter is detected so that that portion of the cas protocol is honored. Right now if there is an existing CAS non-mfa session and a service sends back the `authn_method=MFA-YOUR-METHOD-HERE` in conjunction with `renew=true` the renew parameter is ignored and it just drops them on the second factor authentication screen. Only added renew as supporting `gateway` in conjunction with `authn_method` doesn't make sense in my head.