### PR TITLE
Updated exception being caught and handled

### DIFF
--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/AbstractMultiFactorAuthenticationViaFormAction.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/AbstractMultiFactorAuthenticationViaFormAction.java
@@ -15,7 +15,7 @@ import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.AuthenticationManager;
 import org.jasig.cas.authentication.Credential;
-import org.jasig.cas.authentication.handler.AuthenticationException;
+import org.jasig.cas.authentication.AuthenticationException;
 import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl;
 import org.jasig.cas.authentication.principal.WebApplicationService;
@@ -175,7 +175,7 @@ public abstract class AbstractMultiFactorAuthenticationViaFormAction extends Abs
             MultiFactorRequestContextUtils.setAuthentication(context, auth);
             return result;
         } catch (final AuthenticationException e) {
-            populateErrorsInstance(e.getCode(), messageContext);
+            populateErrorsInstance(e.getMessage(), messageContext);
             MultiFactorRequestContextUtils.setAuthenticationExceptionInFlowScope(context, e);
             logger.error(e.getMessage(), e);
         }

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/util/MultiFactorRequestContextUtils.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/util/MultiFactorRequestContextUtils.java
@@ -22,7 +22,7 @@ import net.unicon.cas.mfa.authentication.MultiFactorAuthenticationTransactionCon
 import net.unicon.cas.mfa.authentication.principal.MultiFactorCredentials;
 import net.unicon.cas.mfa.web.support.MultiFactorAuthenticationSupportingWebApplicationService;
 import org.jasig.cas.authentication.Authentication;
-import org.jasig.cas.authentication.handler.AuthenticationException;
+import org.jasig.cas.authentication.AuthenticationException;
 import org.jasig.cas.authentication.principal.Principal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Updated catch and message handling to use the newer org.jasig.cas.authentication.AuthenticationException instead of the deprecated org.jasig.cas.authentication.handler.AuthenticationException from issue #137