### PR TITLE
Multiple code improvements - squid:S1118, squid:S1192, squid:S1149

### DIFF
--- a/cas-mfa-duo/src/main/java/com/duosecurity/DuoWeb.java
+++ b/cas-mfa-duo/src/main/java/com/duosecurity/DuoWeb.java
@@ -21,6 +21,9 @@ public final class DuoWeb {
 	public static final String ERR_SKEY = "ERR|The Duo secret key passed to sign_request() is invalid.";
 	public static final String ERR_AKEY = "ERR|The application secret key passed to sign_request() must be at least " + AKEY_LEN + " characters.";
 	public static final String ERR_UNKNOWN = "ERR|An unknown error has occurred.";
+	public static final String INVALID_RESPONSE = "Invalid response";
+
+	private DuoWeb() {}
 
 	public static String signRequest(final String ikey, final String skey, final String akey, final String username) {
 		final String duoSig;
@@ -90,7 +93,7 @@ public final class DuoWeb {
 
 		final String[] parts = val.split("\\|");
 		if (parts.length != 3) {
-			throw new DuoWebException("Invalid response");
+			throw new DuoWebException(INVALID_RESPONSE);
 		}
 
 		final String uPrefix = parts[0];

--- a/cas-mfa-duo/src/main/java/com/duosecurity/Util.java
+++ b/cas-mfa-duo/src/main/java/com/duosecurity/Util.java
@@ -7,6 +7,9 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 public class Util {
+
+	private Util() {}
+
 	public static String hmacSign(final String skey, final String data)
 			throws NoSuchAlgorithmException, InvalidKeyException {
 		final SecretKeySpec key = new SecretKeySpec(skey.getBytes(), "HmacSHA1");

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/DefaultRegisteredServiceMfaRoleProcessorImpl.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/DefaultRegisteredServiceMfaRoleProcessorImpl.java
@@ -235,6 +235,7 @@ public class DefaultRegisteredServiceMfaRoleProcessorImpl implements RegisteredS
      * A POJO to store data retrieved from the Services Manager.
      */
     private class ServiceMfaData {
+        public static final String CANNOT_BE_NULL = "{} cannot be null";
         private String authenticationMethod;
         private String attributeName;
         private String attributePattern;
@@ -270,15 +271,15 @@ public class DefaultRegisteredServiceMfaRoleProcessorImpl implements RegisteredS
          */
         public boolean isValid() {
             if (this.attributeName == null) {
-                logger.debug("{} cannot be null", MFA_ATTRIBUTE_NAME);
+                logger.debug(CANNOT_BE_NULL, MFA_ATTRIBUTE_NAME);
                 return false;
             }
             if (this.attributePattern == null) {
-                logger.debug("{} cannot be null", MFA_ATTRIBUTE_PATTERN);
+                logger.debug(CANNOT_BE_NULL, MFA_ATTRIBUTE_PATTERN);
                 return false;
             }
             if (this.authenticationMethod == null) {
-                logger.debug("{} cannot be null", MultiFactorAuthenticationRequestResolver.DEFAULT_MFA_METHOD_ATTRIBUTE_NAME);
+                logger.debug(CANNOT_BE_NULL, MultiFactorAuthenticationRequestResolver.DEFAULT_MFA_METHOD_ATTRIBUTE_NAME);
                 return false;
             }
             return true;

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/principal/MultiFactorCredentials.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/authentication/principal/MultiFactorCredentials.java
@@ -12,10 +12,10 @@ import org.jasig.cas.authentication.principal.PrincipalFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -133,9 +133,9 @@ public class MultiFactorCredentials implements Credential, Serializable {
              * when composing the authentication chain for the caller.
              */
             final String principalId = this.chainedAuthentication.get(0).getPrincipal().getId();
-            final Map<String, Object> principalAttributes = new Hashtable<>();
+            final Map<String, Object> principalAttributes = new HashMap<>();
 
-            final Map<String, Object> authenticationAttributes = new Hashtable<>();
+            final Map<String, Object> authenticationAttributes = new HashMap<>();
 
             final List<CredentialMetaData> credentials = new ArrayList<>();
             final Map<String, HandlerResult> successes = new LinkedHashMap<>();

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/CasMultiFactorWebflowConfigurer.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/flow/CasMultiFactorWebflowConfigurer.java
@@ -63,6 +63,7 @@ import java.util.List;
 public class CasMultiFactorWebflowConfigurer implements InitializingBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(CasMultiFactorWebflowConfigurer.class);
 
+    private static final String VIEW_MFA_UNRECOGNIZED_AUTHN_METHOD_ERROR_VIEW = "viewMfaUnrecognizedAuthnMethodErrorView";
     private static final String FLOW_ID_LOGIN = "login";
     private static final String FLOW_ID_LOGOUT = "logout";
 
@@ -156,7 +157,7 @@ public class CasMultiFactorWebflowConfigurer implements InitializingBean {
         addGlobalTransitionIfExceptionIsThrown(flow,
                 STATE_DEFINITION_ID_TGT_EXISTS_CHECK, NoAuthenticationContextAvailable.class);
         addGlobalTransitionIfExceptionIsThrown(flow,
-                "viewMfaUnrecognizedAuthnMethodErrorView", UnrecognizedAuthenticationMethodException.class);
+                VIEW_MFA_UNRECOGNIZED_AUTHN_METHOD_ERROR_VIEW, UnrecognizedAuthenticationMethodException.class);
     }
 
     /**
@@ -272,7 +273,7 @@ public class CasMultiFactorWebflowConfigurer implements InitializingBean {
      * @param flow the flow
      */
     protected void addMultiFactorViewEndStates(final Flow flow) {
-        addEndStateBackedByView(flow, "viewMfaUnrecognizedAuthnMethodErrorView", "casMfaUnrecognizedAuthnMethodErrorView");
+        addEndStateBackedByView(flow, VIEW_MFA_UNRECOGNIZED_AUTHN_METHOD_ERROR_VIEW, "casMfaUnrecognizedAuthnMethodErrorView");
         addEndStateBackedByView(flow, "viewUnknownPrincipalErrorView", "casUnknownPrincipalErrorView");
     }
 
@@ -434,7 +435,7 @@ public class CasMultiFactorWebflowConfigurer implements InitializingBean {
         subflowState.getTransitionSet().add(createTransition(UNKNOWN_PRINCIPAL_ERROR_EVENT_ID,
                 "viewUnknownPrincipalErrorView"));
         subflowState.getTransitionSet().add(createTransition(MFA_UNRECOGNIZED_AUTHN_METHOD_ERROR_EVENT_ID,
-                "viewMfaUnrecognizedAuthnMethodErrorView"));
+                VIEW_MFA_UNRECOGNIZED_AUTHN_METHOD_ERROR_VIEW));
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1192 - String literals should not be duplicated.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava