### PR TITLE
Multiple code improvements - squid:S1213, squid:S00117, squid:S2737, squid:S1148

### DIFF
--- a/cas-mfa-duo/src/main/java/com/duosecurity/Base64.java
+++ b/cas-mfa-duo/src/main/java/com/duosecurity/Base64.java
@@ -1,8 +1,13 @@
 package com.duosecurity;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 
 public class Base64 {
+
+	private static final Logger logger = LoggerFactory.getLogger(Base64.class);
 
 	/*  ******** P U B L I C F I E L D S ******** */
 
@@ -294,6 +299,9 @@ public class Base64 {
 			-9, -9, -9, -9, -9, -9, -9, -9, -9, -9, -9, -9 // Decimal 244 - 255
 	};
 
+	/** Defeats instantiation. */
+	private Base64() {}
+
 	/*  ******** D E T E R M I N E W H I C H A L H A B E T ******** */
 
 	/**
@@ -327,10 +335,6 @@ public class Base64 {
 			return _STANDARD_DECODABET;
 		}
 	} // end getAlphabet
-
-	/** Defeats instantiation. */
-	private Base64() {
-	}
 
 	/*  ******** E N C O D I N G M E T H O D S ******** */
 
@@ -390,12 +394,12 @@ public class Base64 {
 	private static byte[] encode3to4(final byte[] source, final int srcOffset,
 									 final int numSigBytes, final byte[] destination, final int destOffset, final int options) {
 
-		final byte[] ALPHABET = getAlphabet(options);
+		final byte[] alphabet = getAlphabet(options);
 
 		// 1 2 3
 		// 01234567890123456789012345678901 Bit position
 		// --------000000001111111122222222 Array position from threeBytes
-		// --------| || || || | Six bit groups to index ALPHABET
+		// --------| || || || | Six bit groups to index alphabet
 		// >>18 >>12 >> 6 >> 0 Right shift necessary
 		// 0x3f 0x3f 0x3f Additional AND
 
@@ -409,31 +413,43 @@ public class Base64 {
 				| (numSigBytes > 2 ? ((source[srcOffset + 2] << 24) >>> 24) : 0);
 
 		switch (numSigBytes) {
-		case 3:
-			destination[destOffset] = ALPHABET[(inBuff >>> 18)];
-			destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
-			destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
-			destination[destOffset + 3] = ALPHABET[(inBuff) & 0x3f];
-			return destination;
+			case 3:
+				return getBytesCase3(destination, destOffset, alphabet, inBuff);
 
-		case 2:
-			destination[destOffset] = ALPHABET[(inBuff >>> 18)];
-			destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
-			destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
-			destination[destOffset + 3] = EQUALS_SIGN;
-			return destination;
+			case 2:
+				return getBytesForCase2(destination, destOffset, alphabet, inBuff);
 
-		case 1:
-			destination[destOffset] = ALPHABET[(inBuff >>> 18)];
-			destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
-			destination[destOffset + 2] = EQUALS_SIGN;
-			destination[destOffset + 3] = EQUALS_SIGN;
-			return destination;
+			case 1:
+				return getBytesForCase1(destination, destOffset, alphabet, inBuff);
 
-		default:
-			return destination;
+			default:
+				return destination;
 		} // end switch
 	} // end encode3to4
+
+	private static byte[] getBytesCase3(byte[] destination, int destOffset, byte[] ALPHABET, int inBuff) {
+		destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+		destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
+		destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
+		destination[destOffset + 3] = ALPHABET[(inBuff) & 0x3f];
+		return destination;
+	}
+
+	private static byte[] getBytesForCase2(byte[] destination, int destOffset, byte[] ALPHABET, int inBuff) {
+		destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+		destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
+		destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
+		destination[destOffset + 3] = EQUALS_SIGN;
+		return destination;
+	}
+
+	private static byte[] getBytesForCase1(byte[] destination, int destOffset, byte[] ALPHABET, int inBuff) {
+		destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+		destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
+		destination[destOffset + 2] = EQUALS_SIGN;
+		destination[destOffset + 3] = EQUALS_SIGN;
+		return destination;
+	}
 
 	/**
 	 * Performs Base64 encoding on the <code>raw</code> ByteBuffer, writing it
@@ -577,11 +593,6 @@ public class Base64 {
 			}
 			oos.writeObject(serializableObject);
 		} // end try
-		catch (final java.io.IOException e) {
-			// Catch it and then throw it immediately so that
-			// the finally{} block is called for cleanup.
-			throw e;
-		} // end catch
 		finally {
 			try {
 				oos.close();
@@ -865,11 +876,6 @@ public class Base64 {
 				gzos.write(source, off, len);
 				gzos.close();
 			} // end try
-			catch (final java.io.IOException e) {
-				// Catch it and then throw it immediately so that
-				// the finally{} block is called for cleanup.
-				throw e;
-			} // end catch
 			finally {
 				try {
 					gzos.close();
@@ -1010,16 +1016,16 @@ public class Base64 {
 									destination.length, destOffset));
 		} // end if
 
-		final byte[] DECODABET = getDecodabet(options);
+		final byte[] decodabet = getDecodabet(options);
 
 		// Example: Dk==
 		if (source[srcOffset + 2] == EQUALS_SIGN) {
 			// Two ways to do the same thing. Don't know which way I like best.
-			// int outBuff = ( ( DECODABET[ source[ srcOffset ] ] << 24 ) >>> 6
+			// int outBuff = ( ( decodabet[ source[ srcOffset ] ] << 24 ) >>> 6
 			// )
-			// | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
-			final int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-					| ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12);
+			// | ( ( decodabet[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
+			final int outBuff = ((decodabet[source[srcOffset]] & 0xFF) << 18)
+					| ((decodabet[source[srcOffset + 1]] & 0xFF) << 12);
 
 			destination[destOffset] = (byte) (outBuff >>> 16);
 			return 1;
@@ -1028,13 +1034,13 @@ public class Base64 {
 		// Example: DkL=
 		else if (source[srcOffset + 3] == EQUALS_SIGN) {
 			// Two ways to do the same thing. Don't know which way I like best.
-			// int outBuff = ( ( DECODABET[ source[ srcOffset ] ] << 24 ) >>> 6
+			// int outBuff = ( ( decodabet[ source[ srcOffset ] ] << 24 ) >>> 6
 			// )
-			// | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-			// | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 );
-			final int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-					| ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
-					| ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6);
+			// | ( ( decodabet[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
+			// | ( ( decodabet[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 );
+			final int outBuff = ((decodabet[source[srcOffset]] & 0xFF) << 18)
+					| ((decodabet[source[srcOffset + 1]] & 0xFF) << 12)
+					| ((decodabet[source[srcOffset + 2]] & 0xFF) << 6);
 
 			destination[destOffset] = (byte) (outBuff >>> 16);
 			destination[destOffset + 1] = (byte) (outBuff >>> 8);
@@ -1044,15 +1050,15 @@ public class Base64 {
 		// Example: DkLE
 		else {
 			// Two ways to do the same thing. Don't know which way I like best.
-			// int outBuff = ( ( DECODABET[ source[ srcOffset ] ] << 24 ) >>> 6
+			// int outBuff = ( ( decodabet[ source[ srcOffset ] ] << 24 ) >>> 6
 			// )
-			// | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-			// | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 )
-			// | ( ( DECODABET[ source[ srcOffset + 3 ] ] << 24 ) >>> 24 );
-			final int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-					| ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
-					| ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6)
-					| ((DECODABET[source[srcOffset + 3]] & 0xFF));
+			// | ( ( decodabet[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
+			// | ( ( decodabet[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 )
+			// | ( ( decodabet[ source[ srcOffset + 3 ] ] << 24 ) >>> 24 );
+			final int outBuff = ((decodabet[source[srcOffset]] & 0xFF) << 18)
+					| ((decodabet[source[srcOffset + 1]] & 0xFF) << 12)
+					| ((decodabet[source[srcOffset + 2]] & 0xFF) << 6)
+					| ((decodabet[source[srcOffset + 3]] & 0xFF));
 
 			destination[destOffset] = (byte) (outBuff >> 16);
 			destination[destOffset + 1] = (byte) (outBuff >> 8);
@@ -1131,7 +1137,7 @@ public class Base64 {
 							+ len);
 		} // end if
 
-		final byte[] DECODABET = getDecodabet(options);
+		final byte[] decodabet = getDecodabet(options);
 
 		final int len34 = len * 3 / 4; // Estimate on array size
 		final byte[] outBuff = new byte[len34]; // Upper limit on size of output
@@ -1145,7 +1151,7 @@ public class Base64 {
 
 		for (i = off; i < off + len; i++) { // Loop through source
 
-			sbiDecode = DECODABET[source[i] & 0xFF];
+			sbiDecode = decodabet[source[i] & 0xFF];
 
 			// White space, Equals sign, or legit Base64 character
 			// Note the values such as -5 and -9 in the
@@ -1256,7 +1262,7 @@ public class Base64 {
 
 				} // end try
 				catch (final java.io.IOException e) {
-					e.printStackTrace();
+					logger.error("IOException while creating GZIPInputStream", e);
 					// Just return originally-decoded bytes
 				} // end catch
 				finally {

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorAuthenticationSupportingWebApplicationService.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/support/DefaultMultiFactorAuthenticationSupportingWebApplicationService.java
@@ -63,6 +63,25 @@ public final class DefaultMultiFactorAuthenticationSupportingWebApplicationServi
         this.responseType = responseType;
     }
 
+    /**
+     * Create an instance of {@link DefaultMultiFactorAuthenticationSupportingWebApplicationService}.
+     *
+     * @param id the service id, potentially with a jsessionid; still needing excised
+     * @param originalUrl the service url
+     * @param artifactId the artifact id
+     * @param responseType the HTTP method for the response
+     * @param authnMethod the authentication method required for this service
+     * @param authenticationMethodSource the authentication method source for this service
+     */
+    public DefaultMultiFactorAuthenticationSupportingWebApplicationService(
+            final String id, final String originalUrl,
+            final String artifactId, final ResponseType responseType,
+            @NotNull final String authnMethod,
+            @NotNull final AuthenticationMethodSource authenticationMethodSource) {
+        this(id, originalUrl, artifactId, responseType, authnMethod);
+        this.authenticationMethodSource = authenticationMethodSource;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -91,25 +110,6 @@ public final class DefaultMultiFactorAuthenticationSupportingWebApplicationServi
                       .append(this.getAuthenticationMethodSource())
                       .append(this.getId())
                       .toHashCode();
-    }
-
-    /**
-     * Create an instance of {@link DefaultMultiFactorAuthenticationSupportingWebApplicationService}.
-     *
-     * @param id the service id, potentially with a jsessionid; still needing excised
-     * @param originalUrl the service url
-     * @param artifactId the artifact id
-     * @param responseType the HTTP method for the response
-     * @param authnMethod the authentication method required for this service
-     * @param authenticationMethodSource the authentication method source for this service
-     */
-    public DefaultMultiFactorAuthenticationSupportingWebApplicationService(
-            final String id, final String originalUrl,
-            final String artifactId, final ResponseType responseType,
-            @NotNull final String authnMethod,
-            @NotNull final AuthenticationMethodSource authenticationMethodSource) {
-        this(id, originalUrl, artifactId, responseType, authnMethod);
-        this.authenticationMethodSource = authenticationMethodSource;
     }
 
     @Override

--- a/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/view/Cas30ResponseView.java
+++ b/cas-mfa-java/src/main/java/net/unicon/cas/mfa/web/view/Cas30ResponseView.java
@@ -18,6 +18,8 @@ import java.util.Map;
  * @author Misagh Moayyed
  */
 public class Cas30ResponseView extends org.jasig.cas.web.view.Cas30ResponseView {
+    private String authenticationMethodResponseAttribute;
+
     /**
      * Instantiates a new Cas 30 response view.
      *
@@ -26,8 +28,6 @@ public class Cas30ResponseView extends org.jasig.cas.web.view.Cas30ResponseView 
     protected Cas30ResponseView(final AbstractUrlBasedView view) {
         super(view);
     }
-
-    private String authenticationMethodResponseAttribute;
 
     @Override
     protected void prepareMergedOutputModel(final Map<String, Object> model, final HttpServletRequest request,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S2737 -  "catch" clauses should do more than rethrow.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1148
Please let me know if you have any questions.
George Kankava